### PR TITLE
Patch 1

### DIFF
--- a/vp/.htaccess
+++ b/vp/.htaccess
@@ -6,6 +6,14 @@ Options +FollowSymLinks
  
  
 RewriteEngine on
- 
+
+RewriteRule ^(.*)\/(.*)$ https://app.vocpopuli.com/public_view_term/$1/$2 [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} text/turtle
+RewriteRule ^(cupgrin-41249667-vp)(.*)$ https://gitlab.com/publish-vocabs/vocabulary-cup-grinding-v3/-/raw/main/SKOS_Cup_Grinding_v3.ttl  [R=303,L]
+
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteRule ^(cupgrin-41249667-vp)(.*)$ https://gitlab.com/publish-vocabs/vocabulary-cup-grinding-v3/-/raw/main/SKOS_Cup_Grinding_v3.jsonld  [R=303,L]
+
 # Default Redirect
-RewriteRule ^$  https://www.iam.kit.edu/zm/  [R=303,L]
+RewriteRule ^$  https://app.vocpopuli.com  [R=303,L]

--- a/vp/.htaccess
+++ b/vp/.htaccess
@@ -16,4 +16,4 @@ RewriteCond %{HTTP_ACCEPT} application/ld\+json
 RewriteRule ^(cupgrin-41249667-vp)(.*)$ https://gitlab.com/publish-vocabs/vocabulary-cup-grinding-v3/-/raw/main/SKOS_Cup_Grinding_v3.jsonld  [R=303,L]
 
 # Default Redirect
-RewriteRule ^$  https://app.vocpopuli.com  [R=303,L]
+RewriteRule ^$  https://app.vocpopuli.com/  [R=303,L]


### PR DESCRIPTION
Update .htaccess

Attempted changes (@saidfathalla feel free to let me know if these are incorrect in their implementation)

- https://purls.helmholtz-metadaten.de/vp redirects to https://app.vocpopuli.com/ by default

- PURLs of the form https://purls.helmholtz-metadaten.de/vp/[subdir1]/[subdir2] get redirected to https://app.vocpopuli.com/public_view_term/[subdir1]/[subdir2]

- Requests with a "text/turtle" value in their HTTP_ACCEPT header to https://purls.helmholtz-metadaten.de/vp/cupgrin-41249667-vp/... point to https://gitlab.com/publish-vocabs/vocabulary-cup-grinding-v3/-/raw/main/SKOS_Cup_Grinding_v3.ttl

- Requests with a "application/ld+json" value in their HTTP_ACCEPT header to https://purls.helmholtz-metadaten.de/vp/cupgrin-41249667-vp/... point to https://gitlab.com/publish-vocabs/vocabulary-cup-grinding-v3/-/raw/main/SKOS_Cup_Grinding_v3.jsonld