### PR TITLE
Update MMSS .htaccess

### DIFF
--- a/mmss/.htaccess
+++ b/mmss/.htaccess
@@ -7,7 +7,9 @@ Options +FollowSymLinks
  
  
 RewriteEngine on
- 
+
+# Redirect for MMSS ontology suite
+RewriteRule ^$ https://github.com/OCDO/mmss   [R=303,L]
+
 # Redirect for ASMO ontology
 RewriteRule ^asmo$ https://raw.githubusercontent.com/OCDO/asmo/main/asmo.owl   [R=303,L]
- 


### PR DESCRIPTION
There is no redirection to the mmss ontology repo from https://purls.helmholtz-metadaten.de/mmss/

Please feel free to edit appropriately.