### PR TITLE
Change prefix of 'evoks' to 'skosmos'

### DIFF
--- a/skosmos/.htaccess
+++ b/skosmos/.htaccess
@@ -1,0 +1,27 @@
+
+# Contact person name: Gulzaure Abdildina
+# Contact person email: gulzaure.abdildina@kit.edu
+# Artifacts: MatWerkAcronyms, sdv, rdvc, mng
+# Artifacts Names: MatWerk Acronyms Vocabulary, Sample Description Vocabulary, Reference Dataset Vocabulary, MDMC-NEP Glossary of Terms
+# Resource location: https://metarepo.nffa.eu/skosmos/MDMC_NEP_Glossary-1/en/ , https://matwerk.datamanager.kit.edu/skosmos/SampleDescriptionVocabulary-1/en/ , https://matwerk.datamanager.kit.edu/skosmos/ReferenceDataSetVocCreep-1/en/ , https://matwerk.datamanager.kit.edu/skosmos/MatWerkAcronyms-1/en/
+
+Options +FollowSymLinks
+ 
+ 
+RewriteEngine on
+ 
+# Redirect for skosmos/MatWerkAcronyms terms (e.g. skosmos/MatWerkAcronyms/aai)
+RewriteRule ^MatWerkAcronyms/$  https://matwerk.datamanager.kit.edu/skosmos/MatWerkAcronyms-1/en    [R=303,L]
+RewriteRule ^MatWerkAcronyms/(.*)$  https://matwerk.datamanager.kit.edu/skosmos/MatWerkAcronyms-1/en/page/$1    [R=303,L]
+
+# Redirect for skosmos/Sample Description Vocabulary terms (e.g. skosmos/sampleDescription/aai)
+RewriteRule ^sdv/$   https://matwerk.datamanager.kit.edu/skosmos/SampleDescriptionVocabulary-1/en    [R=303,L]
+RewriteRule ^sdv/(.*)$  https://matwerk.datamanager.kit.edu/skosmos/SampleDescriptionVocabulary-1/en/page/$1    [R=303,L]
+
+# Redirect for skosmos/Reference Dataset Vocabulary – Creep terms  
+RewriteRule ^rdvc/$   https://matwerk.datamanager.kit.edu/skosmos/ReferenceDataSetVocCreep-1/en    [R=303,L]
+RewriteRule ^rdvc/(.*)$  https://matwerk.datamanager.kit.edu/skosmos/ReferenceDataSetVocCreep-1/en/page/$1    [R=303,L]
+
+# Redirect for skosmos/MDMC-NEP Glossary of Terms  
+RewriteRule ^mng/$  https://metarepo.nffa.eu/skosmos/MDMC_NEP_Glossary-1/en/    [R=303,L]
+RewriteRule ^mng/(.*)$   https://metarepo.nffa.eu/skosmos/MDMC_NEP_Glossary-1/en/page/$1    [R=303,L]

--- a/skosmos/README.md
+++ b/skosmos/README.md
@@ -1,0 +1,3 @@
+#  SKOSMOS
+Controlled vocabularies used by [MatWerk](https://nfdi-matwerk.de/) and [NEP](https://nffa.eu).
+


### PR DESCRIPTION
Since ‘evoks’ is a misleading prefix, we want to rename it to ‘skosmos’.
How should we handle the redirection from the old prefix?
Is there a policy for this?
Change 'evoks/.htaccess' to
# Redirect for evoks/* (e.g. skosmos/MatWerkAcronyms/aai)
RewriteRule ^(.*)$  https://purls.helmholtz-metadaten.de/skosmos/$1    [R=303,L]

or reuse the redirects of skosmos/.htaccess?